### PR TITLE
feat: granularità output — unico file, per provincia, per comune

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This is a QGIS plugin built using the PyQt framework following the standard QGIS
 - **CatastoIT_GML_Merger_Pro_dialog.py**: UI dialog class that manages the user interface built from the .ui file
 - **CatastoIT_GML_Merger_Pro_dialog_base.ui**: Qt Designer UI file defining the plugin's graphical interface
 - **regions.py**: Data module containing Italian regions and provinces mapping (REGIONS list and PROVINCES_BY_REGION dictionary)
+- **comuni.py**: Lookup table for 7904 comuni × 107 province (codice Belfiore → nome, sigla provincia)
 - **resources.py**: Qt resource file generated from .qrc files containing embedded resources
 - **__init__.py**: Plugin initialization and metadata
 
@@ -23,32 +24,51 @@ This is a QGIS plugin built using the PyQt framework following the standard QGIS
 
 1. **Download**: Fetches regional ZIP files from geodati.gov.it URLs
 2. **Extraction**: Decompresses province and municipality ZIP files with memory optimization
-3. **Merging**: Combines GML files into unified datasets
-4. **Conversion**: Transforms to GPKG format with automatic field calculation
-5. **Loading**: Optionally loads results into QGIS with predefined styling
+3. **Merging**: Combines GML files into unified datasets using 3-level fallback strategy
+4. **Field calculation**: Adds foglio, particella, sez_censuaria, comune via pure sqlite3 (thread-safe)
+5. **CRS fix**: Labels GPKG as EPSG:4326 to fix axis order issue with GDAL 3.12+/PROJ 9.7+
+6. **Loading**: Optionally loads results into QGIS with predefined styling
 
 ### Data Processing Features
 
 - Downloads from RNDT (Repertorio Nazionale Dati Territoriali) at geodati.gov.it
 - Handles both MAP (cadastral maps) and PLE (parcels) file types
-- Extracts and adds calculated fields: Foglio (sheet), Particella (parcel), sez_censuaria (census section)
-- Supports CRS reprojection from native RDN2008/ETRF2000 (EPSG:7794)
-- Background processing with progress logging
+- Extracts and adds calculated fields: Foglio (sheet), Particella (parcel), sez_censuaria (census section), comune
+- Optional filtering by comune (codice Belfiore)
+- Output granularity: unico file / un file per provincia / un file per comune
+- CRS: native data is EPSG:6706 (RDN2008); GPKG labeled as EPSG:4326 (same coordinates, <1m diff for Italy)
+- Background processing (QgsTask) with progress logging — no Qt objects in background thread
 - Temporary directory management with automatic cleanup
+
+### Output Granularity
+
+- **Unico**: single output file per type; name includes province suffix + optional comuni codes
+- **Per provincia**: one file per province; `{base}_{PROV}.gpkg`; no province/comuni suffix on base
+- **Per comune**: one file per comune; `{base}_{PROV}_{BELFIORE}.gpkg`; no province/comuni suffix on base
+
+### Known Technical Notes
+
+- GPKG R-tree triggers use `ST_IsEmpty()` (SpatiaLite), unavailable in plain sqlite3.
+  Fix: drop all triggers on the table before `executemany UPDATE`, recreate not needed (geometry unchanged).
+- EPSG:6706 with GDAL 3.12+ produces `Data axis to CRS axis mapping: 2,1` → layer invisible with OSM background.
+  Fix: label GPKG as EPSG:4326 via sqlite3 after merge.
+- Destroying `QgsVectorLayer` in a `QgsTask` background thread causes access violation on Windows.
+  Fix: use pure sqlite3 for all GPKG manipulation in background tasks.
+- Signal connections in `run()` must be disconnected before reconnecting to prevent duplicate task spawning.
 
 ## Development Commands
 
 This is a QGIS plugin project with no build system or testing framework. Development involves:
 
 ### Plugin Installation
-- Copy plugin directory to QGIS plugins folder: `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/`
+- Copy plugin directory to QGIS plugins folder: `%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\` (Windows)
 - Enable plugin in QGIS Plugin Manager
 - Restart QGIS to load changes
 
 ### Testing
 - Manual testing within QGIS environment
-- Test with different Italian regions and province combinations
-- Verify GPKG output and field calculations
+- Test all three output granularities (unico, per provincia, per comune) with and without comuni filter
+- Verify GPKG output, field calculations, and layer visibility with OSM background
 
 ### Resource Compilation
 If modifying UI or resources, use QGIS development tools:
@@ -58,13 +78,13 @@ If modifying UI or resources, use QGIS development tools:
 ## Key Dependencies
 
 - QGIS 3.22+ with PyQt5/6
-- Python 3.7+ with standard libraries (urllib, zipfile, tempfile, etc.)
+- Python 3.7+ with standard libraries (urllib, zipfile, tempfile, sqlite3, etc.)
 - QGIS processing framework
 - GDAL/OGR for spatial data handling
 
 ## Configuration Notes
 
-- Plugin metadata in metadata.txt defines QGIS compatibility and plugin information
+- Plugin metadata in `metadata.txt` defines QGIS compatibility — **single source of truth for version**
 - Regional data URLs are hardcoded in processing logic
-- No external configuration files or environment setup required
+- `.env` file stores `GITHUB_TOKEN` (not tracked by git)
 - Plugin creates temporary directories during processing with automatic cleanup on dialog close

--- a/CatastoIT_GML_Merger_Pro.py
+++ b/CatastoIT_GML_Merger_Pro.py
@@ -502,8 +502,9 @@ class CatastoIT_GML_Merger_Pro:
             self.dlg.cb_file_type.setCurrentIndex(0)
             self.dlg.cb_format.setCurrentIndex(0)
             self.dlg.cb_region.setCurrentIndex(0)
-            self.dlg.list_provinces.clearSelection()  # Cancella le selezioni dalla lista
-            self.dlg._reset_comuni_widget()
+            # Forza ripopolamento lista province: setCurrentIndex(0) non emette il segnale
+            # se la regione era già a indice 0, lasciando la selezione precedente attiva.
+            self.dlg.update_provinces()
             self.dlg.cb_region.setEnabled(True)
             self.dlg.le_url.setEnabled(True)
             self.dlg.le_url.clear()
@@ -591,10 +592,12 @@ class CatastoIT_GML_Merger_Pro:
             self.dlg.text_log.append("\nElaborazione completata con successo!")
             
             # Aggiorna le informazioni dei percorsi output
-            if result.get('map_output') and result['map_count'] > 0:
-                self.dlg.text_log.append(f"File MAP salvato in: {result['map_output']}")
-            if result.get('ple_output') and result['ple_count'] > 0:
-                self.dlg.text_log.append(f"File PLE salvato in: {result['ple_output']}")
+            if result['map_count'] > 0:
+                for f in result.get('map_outputs', []):
+                    self.dlg.text_log.append(f"File MAP salvato in: {f}")
+            if result['ple_count'] > 0:
+                for f in result.get('ple_outputs', []):
+                    self.dlg.text_log.append(f"File PLE salvato in: {f}")
             
             # Carica i layer se l'opzione è attiva
             if result.get('load_layers', False):
@@ -619,7 +622,11 @@ class CatastoIT_GML_Merger_Pro:
                     layer = QgsVectorLayer(ple_file, base_name, "ogr")
                     if layer.isValid():
                         if os.path.exists(qml_path):
-                            layer.loadNamedStyle(qml_path)
+                            msg, ok = layer.loadNamedStyle(qml_path)
+                            if not ok:
+                                self.dlg.text_log.append(f"Avviso stile PLE: {msg} (percorso: {qml_path})")
+                        else:
+                            self.dlg.text_log.append(f"Avviso: stile QML non trovato in {qml_path}")
                         QgsProject.instance().addMapLayer(layer, parent is None)
                         if parent is not None:
                             parent.addLayer(layer)
@@ -724,23 +731,29 @@ class GmlProcessingTask(QgsTask):
             province_codes = [p.strip().upper() for p in self.inputs['province_code'].split(',')]
             self.log_message.emit(f"Province selezionate: {', '.join(province_codes)}")
             
-            # Modifica il nome dell'output con tutti i codici provincia
+            # Modifica il nome dell'output con tutti i codici provincia.
+            # Per granularità per_comune il suffisso province è omesso: build_output_path
+            # aggiungerà già "{prov}_{belfiore}" come chiave nel nome del file.
+            granularity = self.inputs.get('output_granularity', 'unico')
             province_suffix = "_".join(province_codes)
-            if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
-                base_name = os.path.splitext(self.inputs["map_output"])[0]
-                ext = os.path.splitext(self.inputs["map_output"])[1]
-                self.inputs["map_output"] = f"{base_name}_{province_suffix}{ext}"
-                self.log_message.emit(f"Output MAP aggiornato: {self.inputs['map_output']}")
-            
-            if self.inputs["file_type"] in ["Particelle (PLE)", "Entrambi"]:
-                base_name = os.path.splitext(self.inputs["ple_output"])[0]
-                ext = os.path.splitext(self.inputs["ple_output"])[1]
-                self.inputs["ple_output"] = f"{base_name}_{province_suffix}{ext}"
-                self.log_message.emit(f"Output PLE aggiornato: {self.inputs['ple_output']}")
+            if granularity != 'per_comune':
+                if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
+                    base_name = os.path.splitext(self.inputs["map_output"])[0]
+                    ext = os.path.splitext(self.inputs["map_output"])[1]
+                    self.inputs["map_output"] = f"{base_name}_{province_suffix}{ext}"
+                    self.log_message.emit(f"Output MAP aggiornato: {self.inputs['map_output']}")
+
+                if self.inputs["file_type"] in ["Particelle (PLE)", "Entrambi"]:
+                    base_name = os.path.splitext(self.inputs["ple_output"])[0]
+                    ext = os.path.splitext(self.inputs["ple_output"])[1]
+                    self.inputs["ple_output"] = f"{base_name}_{province_suffix}{ext}"
+                    self.log_message.emit(f"Output PLE aggiornato: {self.inputs['ple_output']}")
 
             # Aggiunge suffisso con codici Belfiore se il filtro comuni è attivo
+            # Per granularità per_comune il suffisso è omesso: build_output_path aggiunge già il codice comune
             comuni_filter = self.inputs.get('comuni_filter', [])
-            if comuni_filter:
+            granularity = self.inputs.get('output_granularity', 'unico')
+            if comuni_filter and granularity != 'per_comune':
                 comuni_suffix = "_".join(comuni_filter)
                 if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
                     base_name = os.path.splitext(self.inputs["map_output"])[0]
@@ -869,7 +882,7 @@ class GmlProcessingTask(QgsTask):
                                                 if granularity == 'per_provincia':
                                                     dest_folder = os.path.join(base_folder, prov_code)
                                                 elif granularity == 'per_comune':
-                                                    dest_folder = os.path.join(base_folder, com_belfiore)
+                                                    dest_folder = os.path.join(base_folder, f"{prov_code}_{com_belfiore}")
                                                 else:
                                                     dest_folder = base_folder
                                                 os.makedirs(dest_folder, exist_ok=True)
@@ -1177,116 +1190,120 @@ class GmlProcessingTask(QgsTask):
                 result = processing.run("native:retainfields", filter_params)
                 output_file = result['OUTPUT']
 
-                # Fix CRS: native:retainfields non propaga il metadato SRS nel GPKG.
-                # Scriviamo EPSG:6706 direttamente nelle tabelle SRS del file GPKG.
-                if output_file.lower().endswith('.gpkg'):
+                # Aggiungi campi calcolati e fix CRS tramite sqlite3 puro (thread-safe, nessun oggetto Qt)
+                if output_file.lower().endswith('.gpkg') and os.path.exists(output_file):
                     try:
-                        crs_ref = QgsCoordinateReferenceSystem('EPSG:6706')
+                        needs_particella = file_type == "PLE"
+                        needs_sez = file_type == "PLE" and self.inputs.get("add_sezione_censuaria", False)
+                        needs_comune = self.inputs.get("add_nome_comune", False)
+
                         conn = sqlite3.connect(output_file)
                         c = conn.cursor()
+
+                        # Nome tabella dal GPKG
+                        table_name = c.execute(
+                            "SELECT table_name FROM gpkg_contents LIMIT 1"
+                        ).fetchone()[0]
+
+                        # Aggiungi colonne (ignora se già esistono)
+                        cols = [("foglio", "TEXT")]
+                        if needs_particella:
+                            cols.append(("particella", "TEXT"))
+                            self.log_message.emit("Aggiunta campo 'particella'...")
+                        if needs_sez:
+                            cols.append(("sez_censuaria", "TEXT"))
+                            self.log_message.emit("Aggiunta campo 'sez_censuaria'...")
+                        if needs_comune:
+                            cols.append(("comune", "TEXT"))
+                            self.log_message.emit("Aggiunta campo 'comune'...")
+                        self.log_message.emit(f"Aggiunta campo 'foglio' al layer {file_type}...")
+                        for col_name, col_type in cols:
+                            try:
+                                c.execute(f'ALTER TABLE "{table_name}" ADD COLUMN "{col_name}" {col_type}')
+                            except Exception:
+                                pass  # colonna già presente
+
+                        # Verifica esistenza ADMINISTRATIVEUNIT
+                        has_au = c.execute(
+                            f"SELECT COUNT(*) FROM pragma_table_info(\"{table_name}\") WHERE name='ADMINISTRATIVEUNIT'"
+                        ).fetchone()[0] > 0
+
+                        # Leggi tutti i record in una sola query
+                        au_col = '"ADMINISTRATIVEUNIT"' if has_au else 'NULL'
+                        rows = c.execute(
+                            f'SELECT fid, gml_id, {au_col} FROM "{table_name}"'
+                        ).fetchall()
+
+                        # Drop trigger R-tree che chiamano ST_IsEmpty (non disponibile
+                        # nel sqlite3 standard — funzione SpatiaLite).
+                        # I trigger si attivano su qualsiasi UPDATE della tabella,
+                        # anche su colonne non geometriche. L'R-tree rimane valido
+                        # perché non modifichiamo la geometria.
+                        triggers = c.execute(
+                            "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?",
+                            (table_name,)
+                        ).fetchall()
+                        for (trig_name,) in triggers:
+                            c.execute(f'DROP TRIGGER IF EXISTS "{trig_name}"')
+
+                        # Calcola valori in Python e accumula per batch update
+                        set_parts = ['"foglio"=?']
+                        if needs_particella:
+                            set_parts.append('"particella"=?')
+                        if needs_sez:
+                            set_parts.append('"sez_censuaria"=?')
+                        if needs_comune and has_au:
+                            set_parts.append('"comune"=?')
+                        set_clause = ", ".join(set_parts)
+
+                        updates = []
+                        for fid, gml_id, au in rows:
+                            gml_id = gml_id or ''
+                            vals = [gml_id[32:36] if len(gml_id) > 36 else '']
+                            if needs_particella:
+                                vals.append(gml_id[39:] if len(gml_id) > 39 else '')
+                            if needs_sez:
+                                vals.append(gml_id[31:32] if len(gml_id) > 32 else '')
+                            if needs_comune and has_au:
+                                vals.append(
+                                    COMUNI_BY_CODE.get(str(au).upper(), ('',))[0] if au else ''
+                                )
+                            vals.append(fid)
+                            updates.append(tuple(vals))
+
+                        c.executemany(
+                            f'UPDATE "{table_name}" SET {set_clause} WHERE fid=?', updates
+                        )
+                        self.log_message.emit(f"Campi calcolati correttamente per il layer {file_type}")
+
+                        # Fix CRS: EPSG:4326 (WGS84) — coordinate identiche a RDN2008 (<1m per l'Italia).
+                        # EPSG:6706 con GDAL 3.12+/PROJ 9.7+ produce axis mapping 2,1 che causa
+                        # rendering errato in QGIS con layer OSM (EPSG:3857).
+                        wkt_4326 = (
+                            'GEOGCS["WGS 84",DATUM["WGS_1984",'
+                            'SPHEROID["WGS 84",6378137,298.257223563]],'
+                            'PRIMEM["Greenwich",0],'
+                            'UNIT["degree",0.0174532925199433],'
+                            'AUTHORITY["EPSG","4326"]]'
+                        )
                         c.execute(
                             "INSERT OR REPLACE INTO gpkg_spatial_ref_sys "
                             "(srs_name, srs_id, organization, organization_coordsys_id, definition) "
                             "VALUES (?,?,?,?,?)",
-                            (crs_ref.description(), 6706, 'EPSG', 6706, crs_ref.toWkt())
+                            ('WGS 84', 4326, 'EPSG', 4326, wkt_4326)
                         )
-                        c.execute("UPDATE gpkg_geometry_columns SET srs_id=6706")
-                        c.execute("UPDATE gpkg_contents SET srs_id=6706")
+                        c.execute("UPDATE gpkg_geometry_columns SET srs_id=4326")
+                        c.execute("UPDATE gpkg_contents SET srs_id=4326")
                         conn.commit()
                         conn.close()
-                        self.log_message.emit("CRS EPSG:6706 assegnato al file GPKG")
+                        self.log_message.emit("CRS EPSG:4326 assegnato al file GPKG")
+
                     except Exception as e:
-                        self.log_message.emit(f"Avviso: impossibile assegnare CRS al GPKG: {e}")
-
-                # Ottimizzazione della generazione dei campi utilizzando operazioni in batch
-                self.log_message.emit(f"Aggiunta campo 'foglio' al layer {file_type}...")
-                output_layer = QgsVectorLayer(output_file, f"{file_type}_Uniti", "ogr")
-                
-                if output_layer.isValid():
-                    # Prepara tutti i campi da aggiungere in una singola operazione
-                    fields_to_add = [QgsField("foglio", QVariant.String)]
-                    if file_type == "PLE":
-                        self.log_message.emit("Aggiunta campo 'particella'...")
-                        fields_to_add.append(QgsField("particella", QVariant.String))
-                        # Aggiungi campo sezione censuaria se richiesto
-                        if self.inputs.get("add_sezione_censuaria", False):
-                            self.log_message.emit("Aggiunta campo 'sez_censuaria'...")
-                            fields_to_add.append(QgsField("sez_censuaria", QVariant.String, len=1))
-                    # Aggiungi campo nome comune se richiesto (vale per MAP e PLE)
-                    if self.inputs.get("add_nome_comune", False):
-                        self.log_message.emit("Aggiunta campo 'comune'...")
-                        fields_to_add.append(QgsField("comune", QVariant.String))
-                    
-                    # Inizia la transazione per le modifiche in batch
-                    output_layer.startEditing()
-                    output_layer.dataProvider().addAttributes(fields_to_add)
-                    output_layer.updateFields()
-                    
-                    # Ottieni gli indici una sola volta fuori dal ciclo
-                    foglio_idx = output_layer.fields().indexFromName("foglio")
-                    particella_idx = output_layer.fields().indexFromName("particella") if file_type == "PLE" else -1
-                    sez_censuaria_idx = output_layer.fields().indexFromName("sez_censuaria") if file_type == "PLE" and self.inputs.get("add_sezione_censuaria", False) else -1
-                    gml_id_idx = output_layer.fields().indexFromName("gml_id")
-                    au_idx = output_layer.fields().indexFromName("ADMINISTRATIVEUNIT")
-                    comune_idx = output_layer.fields().indexFromName("comune") if self.inputs.get("add_nome_comune", False) else -1
-
-                    # Calcola valori una sola volta
-                    needs_particella = file_type == "PLE" and particella_idx >= 0
-                    needs_sez_censuaria = file_type == "PLE" and sez_censuaria_idx >= 0
-                    needs_nome_comune = comune_idx >= 0 and au_idx >= 0
-                    
-                    # Inizializza il buffer per le modifiche prima di usarlo
-                    changes_buffer = {}
-                    
-                    # Usa una singola passata per elaborare tutti i dati
-                    for feature in output_layer.getFeatures():
-                        feature_id = feature.id()
-                        gml_id = feature[gml_id_idx]
-                        
-                        # Estrai foglio (posizioni 32-36) con controllo più efficiente
-                        if len(gml_id) > 36:
-                            foglio = gml_id[32:36]
-                            changes_buffer[feature_id] = {foglio_idx: foglio}
-                            
-                            # Estrai particella per PLE (dalla posizione 39 in poi)
-                            if needs_particella and len(gml_id) > 39:
-                                particella = gml_id[39:]
-                                changes_buffer[feature_id][particella_idx] = particella
-                            
-                            # Estrai sezione censuaria per PLE (indice Python 31, 1 carattere prima del foglio)
-                            if needs_sez_censuaria and len(gml_id) > 32:
-                                sez_censuaria = gml_id[31:32]
-                                changes_buffer[feature_id][sez_censuaria_idx] = sez_censuaria
-
-                        # Aggiungi nome comune da ADMINISTRATIVEUNIT (codice Belfiore)
-                        if needs_nome_comune:
-                            belfiore = feature[au_idx]
-                            if belfiore:
-                                nome_comune = COMUNI_BY_CODE.get(str(belfiore).upper(), ('',))[0]
-                                changes_buffer.setdefault(feature_id, {})[comune_idx] = nome_comune
-                    
-                    # Applica tutte le modifiche in batch
-                    batch_size = 500  # Controlla annullamento ogni 500 feature
-                    batch_count = 0
-                    for feature_id, attrs in changes_buffer.items():
-                        for field_idx, value in attrs.items():
-                            output_layer.changeAttributeValue(feature_id, field_idx, value)
-                        
-                        batch_count += 1
-                        if batch_count % batch_size == 0 and self.isCanceled():
-                            output_layer.rollBack()
-                            self.log_message.emit("Operazione annullata dall'utente")
-                            return None
-                    
-                    # Finalizza le modifiche e controlla errori
-                    success = output_layer.commitChanges()
-                    if success:
-                        self.log_message.emit(f"Campi calcolati correttamente per il layer {file_type}")
-                    else:
-                        self.log_message.emit(f"ERRORE: Impossibile aggiornare i campi per il layer {file_type}")
-                        self.log_message.emit(str(output_layer.commitErrors()))
+                        self.log_message.emit(f"ERRORE nel calcolo campi: {e}")
+                        import traceback
+                        self.log_message.emit(traceback.format_exc())
                 else:
-                    self.log_message.emit(f"ERRORE: Il layer di output {file_type} non è valido")
+                    self.log_message.emit(f"ERRORE: file output non trovato: {output_file}")
 
                 # Pulizia risorse temporanee in modo più robusto
                 try:
@@ -1296,7 +1313,6 @@ class GmlProcessingTask(QgsTask):
                             QgsProject.instance().removeMapLayer(layer_id)
                     
                     # Libera memoria e dai tempo al sistema
-                    output_layer = None
                     gc.collect()
                     time.sleep(1)
                     

--- a/CatastoIT_GML_Merger_Pro.py
+++ b/CatastoIT_GML_Merger_Pro.py
@@ -534,12 +534,25 @@ class CatastoIT_GML_Merger_Pro:
             self.dlg.le_map_output.setPlaceholderText("Solo nome file (es. mappe_catastali)")
             self.dlg.le_ple_output.setPlaceholderText("Solo nome file (es. particelle_catastali)")
         
+        # Disconnetti segnali prima di riconnetterli per evitare connessioni duplicate
+        # (run() viene chiamata ad ogni apertura del plugin, non solo alla prima)
+        try: self.dlg.cb_region.currentIndexChanged.disconnect(url_update)
+        except Exception: pass
+        try: self.dlg.cb_file_type.currentIndexChanged.disconnect(aggiorna_campi_output)
+        except Exception: pass
+        try: self.dlg.btn_process.clicked.disconnect()
+        except Exception: pass
+        try: self.dlg.btn_close.clicked.disconnect()
+        except Exception: pass
+        try: self.dlg.btn_stop.clicked.disconnect()
+        except Exception: pass
+
         self.dlg.cb_region.currentIndexChanged.connect(url_update)
-        self.dlg.cb_file_type.currentIndexChanged.connect(aggiorna_campi_output)                                                       
+        self.dlg.cb_file_type.currentIndexChanged.connect(aggiorna_campi_output)
         self.dlg.btn_process.clicked.connect(process_gml_files)
         self.dlg.btn_close.clicked.connect(pulisci_temporanea)
-        self.dlg.btn_stop.clicked.connect(self.stop_processing)  # Ora funzionerà correttamente
-        self.dlg.btn_stop.setEnabled(False)  # Disabilitato all'avvio
+        self.dlg.btn_stop.clicked.connect(self.stop_processing)
+        self.dlg.btn_stop.setEnabled(False)
         
         # Imposta lo stato iniziale dei campi di output
         aggiorna_campi_output()
@@ -731,40 +744,38 @@ class GmlProcessingTask(QgsTask):
             province_codes = [p.strip().upper() for p in self.inputs['province_code'].split(',')]
             self.log_message.emit(f"Province selezionate: {', '.join(province_codes)}")
             
-            # Modifica il nome dell'output con tutti i codici provincia.
-            # Per granularità per_comune il suffisso province è omesso: build_output_path
-            # aggiungerà già "{prov}_{belfiore}" come chiave nel nome del file.
+            # Modifica il nome dell'output in base alla granularità:
+            # - unico: aggiunge suffisso province + eventuale suffisso comuni
+            # - per_provincia: build_output_path aggiunge già "_EN"/"_RG" → nessun prefisso
+            # - per_comune: build_output_path aggiunge già "_EN_A098" → nessun prefisso
             granularity = self.inputs.get('output_granularity', 'unico')
-            province_suffix = "_".join(province_codes)
-            if granularity != 'per_comune':
+            comuni_filter = self.inputs.get('comuni_filter', [])
+
+            if granularity == 'unico':
+                province_suffix = "_".join(province_codes)
                 if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
                     base_name = os.path.splitext(self.inputs["map_output"])[0]
                     ext = os.path.splitext(self.inputs["map_output"])[1]
                     self.inputs["map_output"] = f"{base_name}_{province_suffix}{ext}"
                     self.log_message.emit(f"Output MAP aggiornato: {self.inputs['map_output']}")
-
                 if self.inputs["file_type"] in ["Particelle (PLE)", "Entrambi"]:
                     base_name = os.path.splitext(self.inputs["ple_output"])[0]
                     ext = os.path.splitext(self.inputs["ple_output"])[1]
                     self.inputs["ple_output"] = f"{base_name}_{province_suffix}{ext}"
                     self.log_message.emit(f"Output PLE aggiornato: {self.inputs['ple_output']}")
 
-            # Aggiunge suffisso con codici Belfiore se il filtro comuni è attivo
-            # Per granularità per_comune il suffisso è omesso: build_output_path aggiunge già il codice comune
-            comuni_filter = self.inputs.get('comuni_filter', [])
-            granularity = self.inputs.get('output_granularity', 'unico')
-            if comuni_filter and granularity != 'per_comune':
-                comuni_suffix = "_".join(comuni_filter)
-                if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
-                    base_name = os.path.splitext(self.inputs["map_output"])[0]
-                    ext = os.path.splitext(self.inputs["map_output"])[1]
-                    self.inputs["map_output"] = f"{base_name}_{comuni_suffix}{ext}"
-                    self.log_message.emit(f"Output MAP con filtro comuni: {self.inputs['map_output']}")
-                if self.inputs["file_type"] in ["Particelle (PLE)", "Entrambi"]:
-                    base_name = os.path.splitext(self.inputs["ple_output"])[0]
-                    ext = os.path.splitext(self.inputs["ple_output"])[1]
-                    self.inputs["ple_output"] = f"{base_name}_{comuni_suffix}{ext}"
-                    self.log_message.emit(f"Output PLE con filtro comuni: {self.inputs['ple_output']}")
+                if comuni_filter:
+                    comuni_suffix = "_".join(comuni_filter)
+                    if self.inputs["file_type"] in ["Mappe (MAP)", "Entrambi"]:
+                        base_name = os.path.splitext(self.inputs["map_output"])[0]
+                        ext = os.path.splitext(self.inputs["map_output"])[1]
+                        self.inputs["map_output"] = f"{base_name}_{comuni_suffix}{ext}"
+                        self.log_message.emit(f"Output MAP con filtro comuni: {self.inputs['map_output']}")
+                    if self.inputs["file_type"] in ["Particelle (PLE)", "Entrambi"]:
+                        base_name = os.path.splitext(self.inputs["ple_output"])[0]
+                        ext = os.path.splitext(self.inputs["ple_output"])[1]
+                        self.inputs["ple_output"] = f"{base_name}_{comuni_suffix}{ext}"
+                        self.log_message.emit(f"Output PLE con filtro comuni: {self.inputs['ple_output']}")
 
             # Contatori per i file
             ple_count = map_count = 0

--- a/CatastoIT_GML_Merger_Pro_dialog_base.ui
+++ b/CatastoIT_GML_Merger_Pro_dialog_base.ui
@@ -372,19 +372,55 @@
       </widget>
      </item>
      <item row="10" column="1">
-      <widget class="QComboBox" name="cb_format">
-       <property name="toolTip">
-        <string>Seleziona il formato di output (Solo GeoPackage!)</string>
-       </property>
-       <property name="editable">
-        <bool>false</bool>
-       </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_format">
        <item>
-        <property name="text">
-         <string>GPKG</string>
-        </property>
+        <widget class="QComboBox" name="cb_format">
+         <property name="toolTip">
+          <string>Seleziona il formato di output (Solo GeoPackage!)</string>
+         </property>
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <item>
+          <property name="text">
+           <string>GPKG</string>
+          </property>
+         </item>
+        </widget>
        </item>
-      </widget>
+       <item>
+        <widget class="QLabel" name="label_granularity">
+         <property name="text">
+          <string>Granularità:</string>
+         </property>
+         <property name="toolTip">
+          <string>Scegli come raggruppare i file di output</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cb_output_granularity">
+         <property name="toolTip">
+          <string>Tutti i comuni in un unico file / un file per provincia / un file per comune</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Unico file (tutti i comuni)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Un file per provincia</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Un file per comune</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="21" column="0" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout_2"/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guida al plugin CatastoIT_GML_Merger_Pro per QGIS
 
-> **v0.7** — [Guida online](https://pigreco.github.io/CatastoIT_GML_Merger_Pro/) | [Releases](https://github.com/pigreco/CatastoIT_GML_Merger_Pro/releases) | [Segnala un problema](https://github.com/pigreco/CatastoIT_GML_Merger_Pro/issues)
+> **v0.8** — [Guida online](https://pigreco.github.io/CatastoIT_GML_Merger_Pro/) | [Releases](https://github.com/pigreco/CatastoIT_GML_Merger_Pro/releases) | [Segnala un problema](https://github.com/pigreco/CatastoIT_GML_Merger_Pro/issues)
 
 ## Descrizione generale
 **CatastoIT_GML_Merger_Pro** è un plugin avanzato per QGIS che consente di scaricare, estrarre e unire file GML del catasto italiano. Il plugin permette di lavorare con file di mappa (MAP) e particelle (PLE), convertendoli nel formato GPKG e aggiungendo i campi foglio, particella, sezione censuaria e nome del comune per un'integrazione completa nei flussi di lavoro GIS.
@@ -25,6 +25,7 @@
 14. **Guida online** *(nuovo in v0.5)*: Documentazione completa su [GitHub Pages](https://pigreco.github.io/CatastoIT_GML_Merger_Pro/)
 15. **Stile predefinito PLE** *(nuovo in v0.6)*: Al caricamento in QGIS, il layer particelle viene visualizzato con renderer a regole — particelle trasparenti, strade in grigio, acque in blu
 16. **Resilienza GML non validi** *(nuovo in v0.7)*: File GML corrotti o non validi vengono automaticamente saltati con avviso nel log — il processo continua con i file validi senza interrompersi
+17. **Granularità output** *(nuovo in v0.8)*: Nuova combobox per scegliere come aggregare i file di output — unico file (comportamento classico), un file per provincia o un file per comune; nei modi multi-file i layer vengono caricati in QGIS all'interno di un gruppo dedicato nel pannello Layer
 
 ## Come utilizzare il plugin
 
@@ -35,7 +36,7 @@
 5. Seleziona il **tipo di file** da elaborare (Mappe, Particelle o Entrambi)
 6. Se lavori con Particelle, puoi attivare l'opzione **"Aggiungi Sezione Censuaria nelle Particelle"**
 7. *(Opzionale)* Attiva **"Aggiungi Nome Comune"** per includere il campo `comune` nell'output *(v0.5)*
-8. Scegli il **formato di output** (solo GPKG)
+8. Scegli il **formato di output** (solo GPKG) e la **granularità** (unico file / per provincia / per comune) *(v0.8)*
 9. Definisci la **cartella di destinazione** e i nomi dei file di output
 10. *(Opzionale)* Seleziona una **cartella temporanea** se quella di sistema ha poco spazio
 11. *(Opzionale)* Seleziona il **CRS di output** per riproiettare i dati

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@
 - Spazio su disco sufficiente per i dati temporanei e di output
 - Python 3.7 o superiore con librerie GDAL/OGR
 
+## Test v0.8 — Granularità output
+
+| Tipo | Granularità | Filtro comuni | Output | Esito |
+|---|---|---|---|---|
+| PLE | Unico file | sì | `pll_AG_CT_A026_A896.gpkg` | ✅ |
+| PLE | Un file per provincia | sì | `pll_EN.gpkg`, `pll_SR.gpkg` | ✅ |
+| PLE | Un file per comune | sì | `pll_EN_A098.gpkg`, `pll_RG_A014.gpkg` | ✅ |
+| MAP | Unico file | sì | `map_AQ_CH_A018_A367.gpkg` | ✅ |
+| MAP | Un file per provincia | sì | `map_CL.gpkg`, `map_EN.gpkg`, `map_TP.gpkg` | ✅ |
+| MAP | Un file per comune | sì | `map_AG_F126.gpkg`, `map_ME_A194.gpkg` | ✅ |
+
 ## Disclaimer
 
 L'autore del plugin non è un developer ma è riuscito a realizzare il plugin con l'ausilio della AI.

--- a/docs/index.html
+++ b/docs/index.html
@@ -251,6 +251,7 @@
   <a href="#tipi-file">Tipi di file</a>
   <a href="#campi">Campi calcolati</a>
   <a href="#filtro-comuni">Filtro Comuni</a>
+  <a href="#granularita">Granularità Output</a>
   <a href="#output">Output</a>
   <a href="#note">Note tecniche</a>
   <a href="#faq">FAQ</a>
@@ -355,6 +356,15 @@
       </li>
       <li>
         <div>
+          <strong>Granularità Output</strong><br>
+          Scegli come aggregare i dati nel GeoPackage di output:
+          <em>Unico file (tutti i comuni)</em>, <em>Un file per provincia</em>
+          o <em>Un file per comune</em>. Vedi la sezione
+          <a href="#granularita">Granularità Output</a> per i dettagli.
+        </div>
+      </li>
+      <li>
+        <div>
           <strong>Nome file output</strong><br>
           Inserisci il nome del file di output (senza estensione).
           L'estensione <code>.gpkg</code> viene aggiunta automaticamente.
@@ -398,6 +408,7 @@
       <tr><td><strong>Cartella destinazione</strong></td><td>Dove salvare i GeoPackage finali</td></tr>
       <tr><td><strong>Cartella temporanea</strong></td><td>Cartella per file intermedi (opzionale, usa temp di sistema se vuota)</td></tr>
       <tr><td><strong>Formato Output</strong></td><td>Solo GeoPackage (.gpkg)</td></tr>
+      <tr><td><strong>Granularità Output</strong></td><td>Unico file / per provincia / per comune (vedi sezione dedicata)</td></tr>
       <tr><td><strong>Nome File MAPPE / PARTICELLE</strong></td><td>Nome del file di output senza estensione</td></tr>
       <tr><td><strong>Riproietta</strong></td><td>CRS di destinazione opzionale (default EPSG:6706)</td></tr>
       <tr><td><strong>Carica layer in QGIS</strong></td><td>Aggiunge i layer al progetto al termine</td></tr>
@@ -513,6 +524,64 @@
       con i codici Belfiore dei comuni selezionati. Esempio:
     </p>
     <pre>particelle_catastali_A662_A089.gpkg   ← filtro con 2 comuni</pre>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════ GRANULARITÀ OUTPUT -->
+  <section id="granularita">
+    <h2>Granularità Output</h2>
+    <p>
+      La combobox <strong>Granularità</strong> (nella stessa riga di <em>Formato Output</em>)
+      controlla come i dati vengono aggregati nei file GeoPackage prodotti.
+    </p>
+
+    <div class="card">
+      <h3>Unico file (tutti i comuni) <span class="badge badge-green">Default</span></h3>
+      <p>
+        Comportamento classico: tutti i comuni delle province selezionate vengono
+        fusi in <strong>un unico GeoPackage</strong> per tipo (MAP e/o PLE).
+      </p>
+      <pre>mappe_catastali_RM_LT.gpkg
+particelle_catastali_RM_LT.gpkg</pre>
+    </div>
+
+    <div class="card">
+      <h3>Un file per provincia <span class="badge badge-blue">Nuovo</span></h3>
+      <p>
+        Il plugin produce <strong>un GeoPackage separato per ogni provincia</strong> elaborata.
+        Al nome base viene aggiunto il codice provincia come suffisso.
+      </p>
+      <pre>mappe_catastali_RM.gpkg
+mappe_catastali_LT.gpkg
+particelle_catastali_RM.gpkg
+particelle_catastali_LT.gpkg</pre>
+      <p>
+        Se l'opzione <em>Carica layer in QGIS</em> è attiva, tutti i layer vengono
+        caricati all'interno di un <strong>gruppo</strong> nel pannello Layer denominato
+        <em>Catasto – per provincia</em>.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>Un file per comune <span class="badge badge-blue">Nuovo</span></h3>
+      <p>
+        Il plugin produce <strong>un GeoPackage separato per ogni comune</strong> elaborato.
+        Al nome base viene aggiunto il codice Belfiore del comune come suffisso.
+      </p>
+      <pre>particelle_catastali_H501.gpkg   ← Roma
+particelle_catastali_A662.gpkg   ← Agrigento
+particelle_catastali_F205.gpkg   ← Milano</pre>
+      <p>
+        Se l'opzione <em>Carica layer in QGIS</em> è attiva, tutti i layer vengono
+        caricati all'interno di un <strong>gruppo</strong> nel pannello Layer denominato
+        <em>Catasto – per comune</em>.
+      </p>
+    </div>
+
+    <div class="alert">
+      <strong>Nota sulla riproiezione:</strong> se è selezionato un CRS diverso da EPSG:6706,
+      ogni file di output viene riproiettato individualmente. Se la riproiezione di un singolo
+      file fallisce, il file viene comunque caricato nel CRS originale EPSG:6706.
+    </div>
   </section>
 
   <!-- ═══════════════════════════════════════════════════ OUTPUT -->

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=CatastoIT_GML_Merger_Pro
 qgisMinimumVersion=3.22
 description=Download, estrazione e fusione file GML catastali italiani con filtro per comune
-version=0.7
+version=0.8
 author=Salvatore Fiandaca, Giulio Fattori
 email=pigrecoinfinito@gmail.com
 
@@ -26,6 +26,7 @@ changelog= v 0.1 Scarica set particelle e mappe catastali per regione in formato
 	v 0.5 Aggiunto campo nome comune (lookup codice Belfiore); fix SRS nel GPKG dopo retainfields; guida online su GitHub Pages; UI: provincia nella lista comuni, versione nel titolo finestra
 	v 0.6 Stile predefinito per layer PLE: renderer a regole per particelle (trasparente), strade (grigio) e acque (blu)
 	v 0.7 Resilienza file GML: file non validi vengono saltati con avviso nel log, il processo continua con i file validi
+	v 0.8 Granularità output: nuova opzione per salvare i dati in un unico file, un file per provincia o un file per comune; caricamento in QGIS con gruppo layer dedicato per le modalità multi-file
 
 # Tags are comma separated with spaces allowed
 tags=catasto, particelle, fogli, regione, provincia, comune, italia, gml, gpkg, ade


### PR DESCRIPTION
## Cosa cambia

- Aggiunge combobox **Granularità** con tre modalità:
  - **Unico file** — comportamento classico; nome file include suffisso province + eventuali codici Belfiore comuni
  - **Un file per provincia** — un GPKG per ogni provincia selezionata; nome file `{base}_{PROV}.gpkg`
  - **Un file per comune** — un GPKG per ogni comune selezionato; nome file `{base}_{PROV}_{BELFIORE}.gpkg`
- Nelle modalità multi-file i layer vengono caricati in QGIS in un gruppo nel pannello Layer
- Fix nomi file: suffisso province e comuni solo per modalità unico
- Fix task paralleli: disconnect segnali prima di ogni connect in `run()`
- Fix CRS EPSG:4326 invece di EPSG:6706 (axis order GDAL 3.12+/PROJ 9.7+)
- Fix campi calcolati via sqlite3 puro (no QgsVectorLayer in thread background → no access violation)
- Fix trigger R-tree `ST_IsEmpty` in sqlite3 standard

## Test completati ✅

| Tipo | Granularità | Filtro comuni | Output |
|---|---|---|---|
| PLE | Unico file | sì | `pll_AG_CT_A026_A896.gpkg` |
| PLE | Un file per provincia | sì | `pll_EN.gpkg`, `pll_SR.gpkg` |
| PLE | Un file per comune | sì | `pll_EN_A098.gpkg`, `pll_RG_A014.gpkg` |
| MAP | Unico file | sì | `map_AQ_CH_A018_A367.gpkg` |
| MAP | Un file per provincia | sì | `map_CL.gpkg`, `map_EN.gpkg`, `map_TP.gpkg` |
| MAP | Un file per comune | sì | `map_AG_F126.gpkg`, `map_ME_A194.gpkg` |

Closes #39